### PR TITLE
database.ymlの修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: pictweet_development
+  database: pictweet_rspec_practice_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: pictweet_test
+  database: pictweet_rspec_practice_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -50,6 +50,6 @@ test:
 #
 production:
   <<: *default
-  database: pictweet_production
+  database: pictweet_rspec_practice_production
   username: pictweet
   password: <%= ENV["PICTWEET_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
**◎解決したい課題**
練習問題のdatabase.ymlのデータベース名が
元のpictweetのdatabase名と同じことによって起きるエラー

**◎解決策**
database名をそれぞれ「pictweet_rspec_practice」と修正しました。
